### PR TITLE
Fixed KORIN_FATAL

### DIFF
--- a/packages/korin/include/korin/korin.h
+++ b/packages/korin/include/korin/korin.h
@@ -9,6 +9,7 @@
 
 #include "korin/application.h"
 #include "korin/log.h"
+#include "korin/util/assert.h"
 
 // ---ENTRY POINT-------------------------------------------
 #include "korin/entry_point.h"

--- a/packages/korin/include/korin/log.h
+++ b/packages/korin/include/korin/log.h
@@ -31,11 +31,11 @@ private:
 #define KORIN_CORE_WARN(...)  ::korin::Log::coreLogger()->warn(__VA_ARGS__)
 #define KORIN_CORE_INFO(...)  ::korin::Log::coreLogger()->info(__VA_ARGS__)
 #define KORIN_CORE_TRACE(...) ::korin::Log::coreLogger()->trace(__VA_ARGS__)
-#define KORIN_CORE_FATAL(...) ::korin::Log::coreLogger()->fatal(__VA_ARGS__)
+#define KORIN_CORE_FATAL(...) ::korin::Log::coreLogger()->critical(__VA_ARGS__)
 
 // Client log macros
 #define KORIN_ERROR(...) ::korin::Log::clientLogger()->error(__VA_ARGS__)
 #define KORIN_WARN(...)  ::korin::Log::clientLogger()->warn(__VA_ARGS__)
 #define KORIN_INFO(...)  ::korin::Log::clientLogger()->info(__VA_ARGS__)
 #define KORIN_TRACE(...) ::korin::Log::clientLogger()->trace(__VA_ARGS__)
-#define KORIN_FATAL(...) ::korin::Log::clientLogger()->fatal(__VA_ARGS__)
+#define KORIN_FATAL(...) ::korin::Log::clientLogger()->critical(__VA_ARGS__)

--- a/packages/korin/include/korin/util/assert.h
+++ b/packages/korin/include/korin/util/assert.h
@@ -3,6 +3,7 @@
 #ifdef KORIN_ASSERTIONS
 
 #include <iostream>
+#include "korin/log.h"
 
 // Define a platform-independent debug break
 #if defined(_MSC_VER)
@@ -19,7 +20,7 @@
    if (expr) {} \
    else \
    { \
-      reportKorinDebugMessage(#expr, __FILE__, __LINE__); \
+      KORIN_FATAL("ASSERT FAILURE: {0} {1} {2}", #expr, __FILE__, __LINE__); \
       KORIN_DEBUG_BREAK(); \
    }
 


### PR DESCRIPTION
Fixed an incorrect spdlog function call and now use the KORIN_FATAL macro for Korin asserts.